### PR TITLE
chore: moved regenerator-runtime to devdependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "jest": "29.7.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
+        "regenerator-runtime": "0.14.1",
         "resize-observer-polyfill": "^1.5.1",
         "rosie": "2.1.1",
         "semantic-release": "^21.0.7"
@@ -45,8 +46,7 @@
         "prop-types": "^15.5.10",
         "react": "^17.0.2",
         "react-dom": "^16.9.0 || ^17.0.0",
-        "react-router-dom": "^6.0.0",
-        "regenerator-runtime": "0.14.1"
+        "react-router-dom": "^6.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "react-dom": "17.0.2",
     "resize-observer-polyfill": "^1.5.1",
     "rosie": "2.1.1",
-    "semantic-release": "^21.0.7"
+    "semantic-release": "^21.0.7",
+    "regenerator-runtime": "0.14.1"
   },
   "peerDependencies": {
     "@edx/frontend-platform": "^8.1.0",
@@ -69,7 +70,6 @@
     "prop-types": "^15.5.10",
     "react": "^17.0.2",
     "react-dom": "^16.9.0 || ^17.0.0",
-    "react-router-dom": "^6.0.0",
-    "regenerator-runtime": "0.14.1"
+    "react-router-dom": "^6.0.0"
   }
 }


### PR DESCRIPTION
### Description

Moved `regenerator-runtime` package to devdependencies

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
