### PR TITLE
fix: correct notifications anchor link for tutor settings url

### DIFF
--- a/src/Notification/index.jsx
+++ b/src/Notification/index.jsx
@@ -143,7 +143,11 @@ const Notifications = ({ notificationAppData, showLeftMargin }) => {
                 >
                   {intl.formatMessage(messages.notificationTitle)}
                   <Hyperlink
-                    destination={`${getConfig().ACCOUNT_SETTINGS_URL}/#notifications`}
+                    destination={`${
+                      getConfig().ACCOUNT_SETTINGS_URL && getConfig().ACCOUNT_SETTINGS_URL.endsWith('/')
+                        ? `${getConfig().ACCOUNT_SETTINGS_URL}#notifications`
+                        : `${getConfig().ACCOUNT_SETTINGS_URL}/#notifications`
+                    }`}
                     target="_blank"
                     showLaunchIcon={false}
                   >


### PR DESCRIPTION
Fixes an issue in Tutor-based installations where the ACCOUNT_SETTINGS_URL contain a trailing slash. The destination link to `#notifications` now conditionally adds a slash only when necessary, preventing malformed URLs.
