### PR TITLE
fix: fixed sorting issue

### DIFF
--- a/src/Notification/utils.js
+++ b/src/Notification/utils.js
@@ -30,6 +30,8 @@ export const splitNotificationsByTime = (notificationList) => {
       },
       { today: [], earlier: [] },
     );
+    splittedData.today.sort((a, b) => new Date(b.created) - new Date(a.created));
+    splittedData.earlier.sort((a, b) => new Date(b.created) - new Date(a.created));
   }
   const { today, earlier } = splittedData;
   return { today, earlier };


### PR DESCRIPTION
**Description**
This PR fixes the ordering issue of notifications within the tray tabs.

**Problem:**
Previously, when a user opened the notification tray, closed it, and then reopened it after a new notification was generated, the new notification would appear at the bottom of the list (just above the “Load more notifications” button) instead of at the top.

**Fix:**

Notifications are now sorted in descending order based on their created timestamp after grouping them by time (today and earlier).

This ensures that newly received notifications are always displayed at the top of the list, regardless of tray/tab interactions.

**Screenshot**
<img width="546" alt="Screenshot 2025-07-09 at 12 11 04 PM" src="https://github.com/user-attachments/assets/1a52d6a5-db0a-40a0-b546-b079ae34fb46" />
